### PR TITLE
feat(pki): add SigningService interface, mock implementation and unit…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -156,6 +156,7 @@ set(THEMIS_CORE_SOURCES
     src/storage/rocksdb_wrapper.cpp
     src/storage/base_entity.cpp
     src/storage/key_schema.cpp
+    src/storage/backup_manager.cpp
     
     src/index/secondary_index.cpp
     src/index/graph_index.cpp
@@ -226,6 +227,7 @@ set(THEMIS_CORE_SOURCES
     src/utils/normalizer.cpp
     src/security/pki_key_provider.cpp
     src/security/mock_signing_service.cpp
+    src/security/cms_signing.cpp
     src/auth/jwt_validator.cpp
     src/governance/policy_engine.cpp
     # Geo scaffolding (headers + stubs; safe no-ops until used)
@@ -414,6 +416,7 @@ if(THEMIS_BUILD_TESTS)
     tests/test_wal_archiving.cpp
         tests/test_encryption_e2e.cpp
         tests/test_vault_key_provider.cpp
+    tests/test_wal_backup_manager.cpp
         tests/test_audit_logger.cpp
         tests/test_pii_detector.cpp
         tests/test_retention_manager.cpp
@@ -421,7 +424,8 @@ if(THEMIS_BUILD_TESTS)
         tests/test_http_retention_api.cpp
         tests/test_policy_yaml.cpp
         tests/test_pki_client.cpp
-    tests/test_signing_service.cpp
+        tests/test_signing_service.cpp
+        tests/test_cms_signing.cpp
         tests/test_http_policies_export.cpp
         tests/test_pii_soft_delete.cpp
         tests/test_http_pii_lazy_init.cpp

--- a/include/security/cms_signing.h
+++ b/include/security/cms_signing.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "security/signing.h"
+#include <openssl/x509.h>
+#include <openssl/evp.h>
+#include <memory>
+
+namespace themis {
+
+class CMSSigningService : public SigningService {
+public:
+    // Construct from existing X509 cert and private key (shared ownership)
+    CMSSigningService(std::shared_ptr<X509> cert, std::shared_ptr<EVP_PKEY> pkey);
+    ~CMSSigningService() override;
+
+    SigningResult sign(const std::vector<uint8_t>& data, const std::string& key_id) override;
+    bool verify(const std::vector<uint8_t>& data,
+                const std::vector<uint8_t>& signature,
+                const std::string& key_id) override;
+
+private:
+    std::shared_ptr<X509> cert_;
+    std::shared_ptr<EVP_PKEY> pkey_;
+};
+
+} // namespace themis

--- a/include/storage/backup_manager.h
+++ b/include/storage/backup_manager.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <string>
+#include <system_error>
+
+namespace themis {
+
+/**
+ * Simple BackupManager interface
+ *
+ * Responsibilities (scaffold):
+ * - Trigger incremental/full backups
+ * - Manage WAL archiving (rotate/upload)
+ * - Restore from backup archive
+ *
+ * The current implementation is a lightweight scaffold with a local-FS
+ * checkpoint + WAL copy behavior suitable for unit testing. A production
+ * implementation should integrate with RocksDB checkpoints, S3/backends
+ * and safe restore semantics.
+ */
+class BackupManager {
+public:
+    explicit BackupManager(const std::string& db_path);
+    ~BackupManager();
+
+    // Create an incremental backup snapshot into `dest_dir`.
+    // Returns true on success, false otherwise and sets ec.
+    bool createIncrementalBackup(const std::string& dest_dir, std::error_code& ec);
+
+    // Archive WAL files to dest (placeholder)
+    bool archiveWAL(const std::string& dest_dir, std::error_code& ec);
+
+    // Restore DB from backup directory (placeholder)
+    bool restoreFromBackup(const std::string& src_dir, std::error_code& ec);
+
+private:
+    std::string db_path_;
+};
+
+} // namespace themis

--- a/src/security/cms_signing.cpp
+++ b/src/security/cms_signing.cpp
@@ -1,0 +1,91 @@
+#include "security/cms_signing.h"
+#include <openssl/cms.h>
+#include <openssl/pem.h>
+#include <openssl/bio.h>
+#include <stdexcept>
+
+namespace themis {
+
+CMSSigningService::CMSSigningService(std::shared_ptr<X509> cert, std::shared_ptr<EVP_PKEY> pkey)
+    : cert_(std::move(cert)), pkey_(std::move(pkey)) {}
+
+CMSSigningService::~CMSSigningService() = default;
+
+SigningResult CMSSigningService::sign(const std::vector<uint8_t>& data, const std::string& /*key_id*/) {
+    SigningResult res;
+    res.algorithm = "CMS/DETACHED+SHA256";
+
+    BIO* in = BIO_new_mem_buf(data.data(), static_cast<int>(data.size()));
+    if (!in) throw std::runtime_error("BIO_new_mem_buf failed");
+
+    CMS_ContentInfo* cms = CMS_sign(cert_.get(), pkey_.get(), nullptr, in, CMS_DETACHED | CMS_BINARY);
+    BIO_free(in);
+    if (!cms) {
+        throw std::runtime_error("CMS_sign failed");
+    }
+
+    BIO* out = BIO_new(BIO_s_mem());
+    if (!out) {
+        CMS_ContentInfo_free(cms);
+        throw std::runtime_error("BIO_new failed");
+    }
+
+    if (i2d_CMS_bio(out, cms) <= 0) {
+        BIO_free(out);
+        CMS_ContentInfo_free(cms);
+        throw std::runtime_error("i2d_CMS_bio failed");
+    }
+
+    BUF_MEM* bptr = nullptr;
+    BIO_get_mem_ptr(out, &bptr);
+    if (bptr && bptr->length > 0) {
+        res.signature.assign(reinterpret_cast<uint8_t*>(bptr->data), reinterpret_cast<uint8_t*>(bptr->data) + bptr->length);
+    }
+
+    BIO_free(out);
+    CMS_ContentInfo_free(cms);
+    return res;
+}
+
+bool CMSSigningService::verify(const std::vector<uint8_t>& data,
+                                const std::vector<uint8_t>& signature,
+                                const std::string& /*key_id*/) {
+    BIO* sig_bio = BIO_new_mem_buf(signature.data(), static_cast<int>(signature.size()));
+    if (!sig_bio) return false;
+
+    CMS_ContentInfo* cms = d2i_CMS_bio(sig_bio, nullptr);
+    BIO_free(sig_bio);
+    if (!cms) return false;
+
+    BIO* in = BIO_new_mem_buf(data.data(), static_cast<int>(data.size()));
+    if (!in) {
+        CMS_ContentInfo_free(cms);
+        return false;
+    }
+
+    X509_STORE* store = X509_STORE_new();
+    if (!store) {
+        BIO_free(in);
+        CMS_ContentInfo_free(cms);
+        return false;
+    }
+
+    // Add our cert as trusted for verification (self-signed test use-case)
+    if (X509_STORE_add_cert(store, cert_.get()) != 1) {
+        X509_STORE_free(store);
+        BIO_free(in);
+        CMS_ContentInfo_free(cms);
+        return false;
+    }
+
+    int flags = CMS_BINARY;
+    int ok = CMS_verify(cms, nullptr, store, in, nullptr, flags);
+
+    X509_STORE_free(store);
+    BIO_free(in);
+    CMS_ContentInfo_free(cms);
+
+    return ok == 1;
+}
+
+} // namespace themis

--- a/src/storage/backup_manager.cpp
+++ b/src/storage/backup_manager.cpp
@@ -1,0 +1,58 @@
+#include "storage/backup_manager.h"
+#include <filesystem>
+#include <fstream>
+
+namespace themis {
+
+BackupManager::BackupManager(const std::string& db_path) : db_path_(db_path) {}
+BackupManager::~BackupManager() = default;
+
+bool BackupManager::createIncrementalBackup(const std::string& dest_dir, std::error_code& ec) {
+    namespace fs = std::filesystem;
+    try {
+        fs::create_directories(dest_dir);
+        // Simplified: create a marker file with timestamp — real impl uses RocksDB checkpoint
+        auto marker = fs::path(dest_dir) / "backup.meta";
+        std::ofstream out(marker);
+        out << "backup_of:" << db_path_ << "\n";
+        out << "ts:" << std::to_string(std::time(nullptr)) << "\n";
+        out.close();
+        return true;
+    } catch (const std::exception& e) {
+        ec = std::make_error_code(std::errc::io_error);
+        return false;
+    }
+}
+
+bool BackupManager::archiveWAL(const std::string& dest_dir, std::error_code& ec) {
+    namespace fs = std::filesystem;
+    try {
+        fs::create_directories(dest_dir);
+        // Placeholder: copy any .wal files from db_path_ to dest_dir
+        for (auto& p : fs::directory_iterator(db_path_)) {
+            if (p.path().extension() == ".wal") {
+                fs::copy_file(p.path(), fs::path(dest_dir) / p.path().filename(), fs::copy_options::overwrite_existing);
+            }
+        }
+        return true;
+    } catch (...) {
+        ec = std::make_error_code(std::errc::io_error);
+        return false;
+    }
+}
+
+bool BackupManager::restoreFromBackup(const std::string& src_dir, std::error_code& ec) {
+    namespace fs = std::filesystem;
+    try {
+        // Placeholder: copy files back into db_path_
+        for (auto& p : fs::directory_iterator(src_dir)) {
+            fs::copy_file(p.path(), fs::path(db_path_) / p.path().filename(), fs::copy_options::overwrite_existing);
+        }
+        return true;
+    } catch (...) {
+        ec = std::make_error_code(std::errc::io_error);
+        return false;
+    }
+}
+
+} // namespace themis

--- a/tests/test_cms_signing.cpp
+++ b/tests/test_cms_signing.cpp
@@ -1,0 +1,57 @@
+#include <gtest/gtest.h>
+#include "security/cms_signing.h"
+#include <openssl/evp.h>
+#include <openssl/x509.h>
+#include <openssl/pem.h>
+#include <memory>
+
+using namespace themis;
+
+static std::shared_ptr<EVP_PKEY> generate_rsa_key() {
+    EVP_PKEY_CTX* pctx = EVP_PKEY_CTX_new_id(EVP_PKEY_RSA, nullptr);
+    EVP_PKEY* pkey = nullptr;
+    if (!pctx) return nullptr;
+    if (EVP_PKEY_keygen_init(pctx) <= 0) { EVP_PKEY_CTX_free(pctx); return nullptr; }
+    EVP_PKEY_CTX_set_rsa_keygen_bits(pctx, 2048);
+    if (EVP_PKEY_keygen(pctx, &pkey) <= 0) { EVP_PKEY_CTX_free(pctx); return nullptr; }
+    EVP_PKEY_CTX_free(pctx);
+    return std::shared_ptr<EVP_PKEY>(pkey, EVP_PKEY_free);
+}
+
+static std::shared_ptr<X509> make_self_signed_cert(EVP_PKEY* pkey) {
+    X509* x = X509_new();
+    if (!x) return nullptr;
+    ASN1_INTEGER_set(X509_get_serialNumber(x), 1);
+    X509_gmtime_adj(X509_get_notBefore(x), 0);
+    X509_gmtime_adj(X509_get_notAfter(x), 60*60*24*365);
+    X509_set_pubkey(x, pkey);
+
+    X509_NAME* name = X509_get_subject_name(x);
+    X509_NAME_add_entry_by_txt(name, "CN", MBSTRING_ASC, (unsigned char*)"Themis Test", -1, -1, 0);
+    // issuer = subject (self-signed)
+    X509_set_issuer_name(x, name);
+
+    if (!X509_sign(x, pkey, EVP_sha256())) {
+        X509_free(x);
+        return nullptr;
+    }
+    return std::shared_ptr<X509>(x, X509_free);
+}
+
+TEST(CMSSigning, SignAndVerify) {
+    auto pkey = generate_rsa_key();
+    ASSERT_NE(pkey, nullptr);
+    auto cert = make_self_signed_cert(pkey.get());
+    ASSERT_NE(cert, nullptr);
+
+    CMSSigningService svc(cert, pkey);
+
+    std::string msg = "Test CMS signing payload";
+    std::vector<uint8_t> data(msg.begin(), msg.end());
+
+    auto res = svc.sign(data, "test-key");
+    ASSERT_FALSE(res.signature.empty());
+
+    bool ok = svc.verify(data, res.signature, "test-key");
+    EXPECT_TRUE(ok);
+}

--- a/tests/test_wal_backup_manager.cpp
+++ b/tests/test_wal_backup_manager.cpp
@@ -1,0 +1,35 @@
+#include <gtest/gtest.h>
+#include "storage/backup_manager.h"
+#include <filesystem>
+
+using namespace themis;
+
+TEST(WALBackupManager, CreateAndRestore) {
+    namespace fs = std::filesystem;
+    auto tmp = fs::temp_directory_path() / "themis_test_db";
+    fs::create_directories(tmp);
+    // create a dummy WAL file
+    std::ofstream(tmp / "0001.wal") << "wal-data";
+
+    BackupManager mgr(tmp.string());
+
+    auto dest = fs::temp_directory_path() / "themis_backup";
+    std::error_code ec;
+    ASSERT_TRUE(mgr.createIncrementalBackup(dest.string(), ec));
+    ASSERT_FALSE(ec);
+
+    // Archive WAL
+    auto arch = dest / "wal_archive";
+    ASSERT_TRUE(mgr.archiveWAL(arch.string(), ec));
+    ASSERT_TRUE(fs::exists(arch / "0001.wal"));
+
+    // Restore -> copy back to new dir
+    auto restore_dir = fs::temp_directory_path() / "themis_restore";
+    fs::create_directories(restore_dir);
+    ASSERT_TRUE(mgr.restoreFromBackup(arch.string(), ec));
+
+    // cleanup
+    fs::remove_all(tmp);
+    fs::remove_all(dest);
+    fs::remove_all(restore_dir);
+}


### PR DESCRIPTION
This PR adds a scaffold and first implementations for PKI/eIDAS work and backup scaffolding.

Changes included:
-  interface ().
- Mock signing implementation using OpenSSL EVP (, ).
- CMS-based signing service using OpenSSL CMS (, , ).
- BackupManager scaffold for incremental backups / WAL archiving (, , ).
- Docs: , .

Checklist (what to review / next actions):
- [x] API of  and mock impl (thread-safety, error modes).
- [x] CMS implementation: uses / with DETACHED DER encoding (prototype-level).
- [x] BackupManager scaffold: filesystem-based placeholder, suitable for unit tests only.

Recommended next steps:
1. Integrate  with /Vault/HSM for production key material (feature: key lookup + secure PKCS#11). (1-2d)
2. Extend CMS to CAdES: add signed attributes (signingTime, signaturePolicyId), and signature-policy validation for eIDAS compliance. (1-2d)
3. Implement  (HTTP endpoints) + integration tests that exercise sign/verify flows. (1d)
4. Expand  to use RocksDB checkpoints and add S3 uploader for archive retention. (2-3d)

Notes:
- The PR intentionally supplies scaffolds and unit-tests that generate keys/certs in-memory. No secrets are stored in the repo.
- Production eIDAS compliance requires legal/policy review, signature-policy configuration and potentially use of a qualified trust service provider (QTSP).

If you'd like, I can also:
- Add a reviewer list / assignees to this PR.
- Split PKI and backup scaffolds into two separate PRs (smaller review surface).
- Run a focused CMake build of the new tests in the dev container and report missing system packages.
