### PR TITLE
Potential fix for code scanning alert no. 155: Multiplication result converted to larger type

### DIFF
--- a/src/llm/lora_framework/kernels/vulkan_kernels.cpp
+++ b/src/llm/lora_framework/kernels/vulkan_kernels.cpp
@@ -233,9 +233,9 @@ void launch_matmul_shader(
     VulkanComputePipeline* pipeline = get_pipeline("matmul", sizeof(PushConstants));
     
     // Create buffers
-    size_t size_A = M * K * sizeof(float);
-    size_t size_B = K * N * sizeof(float);
-    size_t size_C = M * N * sizeof(float);
+    size_t size_A = static_cast<size_t>(M) * static_cast<size_t>(K) * sizeof(float);
+    size_t size_B = static_cast<size_t>(K) * static_cast<size_t>(N) * sizeof(float);
+    size_t size_C = static_cast<size_t>(M) * static_cast<size_t>(N) * sizeof(float);
     
     VulkanBuffer buf_A(g_vulkan_state.context.get(), size_A, VulkanBuffer::Usage::DeviceLocal);
     VulkanBuffer buf_B(g_vulkan_state.context.get(), size_B, VulkanBuffer::Usage::DeviceLocal);


### PR DESCRIPTION
Potential fix for [https://github.com/makr-code/ThemisDB/security/code-scanning/155](https://github.com/makr-code/ThemisDB/security/code-scanning/155)

To fix this safely, force multiplication to occur in `size_t` (or another sufficiently wide unsigned type) before multiplying dimensions together. The best minimal fix is to cast one operand in each size expression so the whole expression is promoted before multiplication.

In `src/llm/lora_framework/kernels/vulkan_kernels.cpp`, inside `launch_matmul_shader`, update:
- `size_A = M * K * sizeof(float);`
- `size_B = K * N * sizeof(float);`
- `size_C = M * N * sizeof(float);`

to perform arithmetic as `size_t`, e.g. `static_cast<size_t>(M) * static_cast<size_t>(K) * sizeof(float)` etc.  
No new imports, methods, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
