### PR TITLE
Potential fix for code scanning alert no. 156: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -8,6 +8,9 @@ on:
   pull_request:
     branches: [ "develop" ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -10,9 +10,13 @@ on:
     paths:
       - CMakeLists.txt
       - CMakePresets.json
+      - cmake/*
       - cmake/*/**
+      - include/*
       - include/*/**
+      - src/*
       - src/*/**
+      - tests/*
       - tests/*/**
       - .github/workflows/cmake-multi-platform.yml
 

--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -7,9 +7,21 @@ on:
     branches: [ "develop" ]
   pull_request:
     branches: [ "develop" ]
+    paths:
+      - CMakeLists.txt
+      - CMakePresets.json
+      - cmake/*/**
+      - include/*/**
+      - src/*/**
+      - tests/*/**
+      - .github/workflows/cmake-multi-platform.yml
 
 permissions:
   contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build:


### PR DESCRIPTION
Potential fix for [https://github.com/makr-code/ThemisDB/security/code-scanning/156](https://github.com/makr-code/ThemisDB/security/code-scanning/156)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is least-privileged by default.

Best fix here: define permissions at the workflow root (applies to all jobs unless overridden), immediately after the `on:` triggers and before `jobs:`. For this build/test workflow, `contents: read` is sufficient for `actions/checkout` and reading repository contents. No imports, methods, or additional definitions are needed since this is YAML config only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
